### PR TITLE
fix slicing with index equals to the array length

### DIFF
--- a/array.c
+++ b/array.c
@@ -3494,7 +3494,7 @@ rb_ary_slice_bang(int argc, VALUE *argv, VALUE ary)
 	    pos += orig_len;
 	    if (pos < 0) return Qnil;
 	}
-	else if (orig_len < pos) return Qnil;
+	else if (orig_len <= pos) return Qnil;
 	if (orig_len < pos + len) {
 	    len = orig_len - pos;
 	}


### PR DESCRIPTION
The request to slice an array using an index equal to the array length would return [] instead of **nil**

Issue e.g.:
```
2.4.6 :001 > array = [:peanut, :butter, :and, :jelly]
 => [:peanut, :butter, :and, :jelly] 
2.4.6 :002 > array[4,0]
 => [] 
2.4.6 :003 > array[5,0]
 => nil 
2.4.6 :004 > array[4]
 => nil 
2.4.6 :005 > array[5]
 => nil 
```